### PR TITLE
internet connection check

### DIFF
--- a/core/twin.py
+++ b/core/twin.py
@@ -58,17 +58,17 @@ class Twin(Node):
         self.topic = f"{self.namespace}:{self.unique_name}"
         self.thing_id = f"{self.namespace}:{self.name}"
 
+        self.internet_status = False
+        self.is_device_registered = False
+
         # Services
         TwinServices(self, self.get_name())
 
         # Internet connectivity
-        self.internet_status = False
         socket.setdefaulttimeout(3.0)
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.check_internet_conn = self.create_timer(3.0, self.connection_status)
 
         # Register Device
-        self.is_device_registered = False
         if self.internet_status:
             self.register_device()
 
@@ -266,15 +266,19 @@ class Twin(Node):
         return data
 
     def connection_status(self):
-        try:
-            self.socket.connect((self.twin_url.split("@")[1], 1883))
+        try:     
+            self.socket_ = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self.socket_.connect((self.twin_url.split("@")[1], 1883))
+
             if not self.is_device_registered:
                 self.register_device()
 
             self.internet_status = True
         except socket.error as ex:
             self.internet_status = False
-            self.get_logger().warn("Twin Server ping failed!")
+            self.get_logger().warn(f"Twin Server ping failed: {ex}")
+        finally:
+            del self.socket_
 
 def main():
     rclpy.init()

--- a/core/twin.py
+++ b/core/twin.py
@@ -29,7 +29,41 @@ import requests
 import socket
 
 class Twin(Node):
-    """TODO add documentation."""
+    """
+    Represents a twin device node that interacts with a twin server.
+
+    This class handles the registration, telemetry management, and status checks for a twin device.
+    It extends the ROS 2 Node class and utilizes parameters to configure the device's settings and interactions 
+    with the twin server.
+
+    Attributes:
+        twin_url (str): The URL of the twin server.
+        anonymous (bool): Whether the device should be named randomly.
+        namespace (str): The namespace of the device.
+        name (str): The name of the device.
+        type (str): The type of the device.
+        unique_name (str): The unique name of the device, randomly generated if anonymous is True.
+        attributes (dict): The attributes of the device.
+        definition (str): The definition of the device.
+        topic (str): MQTT topic of the device.
+        thing_id (str): Ditto Thing ID of the device.
+        internet_status (bool): The current internet connection status.
+        is_device_registered (bool): The registration status of the device.
+
+    Methods:
+        __init__(): Initializes the Twin node and sets up parameters and services.
+        get_current_properties(): Retrieves the current properties of the device's stack.
+        get_stack_definition(stack_id): Retrieves the stack definition for a given stack ID.
+        stack(thing_id): Retrieves the stack properties for a given thing ID.
+        set_current_stack(stack, state='unknown'): Sets the current stack state.
+        get_context(): Returns information about the device.
+        register_device(): Registers the device with the twin server.
+        get_registered_telemetries(): Retrieves the registered telemetry properties from the twin server.
+        register_telemetry(telemetry_to_register): Registers or updates a telemetry entry with the twin server.
+        delete_telemetry(telemetry_to_delete): Deletes a telemetry entry from the twin server.
+        device_register_data(): Constructs the data dictionary required for device registration with the twin server.
+        connection_status(): Checks the connection status to the twin server and updates the internet status.
+    """
 
     def __init__(self):
         super().__init__("core_twin")
@@ -129,7 +163,17 @@ class Twin(Node):
         return context
 
     def register_device(self):
-        """ # TODO add docs."""
+        """
+        Registers the device with the twin server.
+
+        This method attempts to register the device by sending a PATCH request to the twin server's API.
+        If the PATCH request results in a 400 status code, it attempts a PUT request with additional data.
+        If the PATCH request results in a 404 status code, it attempts a PUT request with the initial data.
+        The method logs the success or failure of the registration process and updates the device's registration status.
+
+        Returns:
+            int: The HTTP status code from the final registration attempt.
+        """
         res = requests.patch(
             f"{self.twin_url}/api/2/things/{self.thing_id}",
             headers={"Content-type": "application/merge-patch+json"},
@@ -163,7 +207,17 @@ class Twin(Node):
         return res.status_code
 
     def get_registered_telemetries(self):
-        """ # TODO add docs."""
+        """
+        Retrieves the registered telemetry properties from the twin server.
+
+        This method sends a GET request to the twin server's API to fetch the telemetry properties for the specified device.
+        If the request is successful (HTTP status code 200), it logs an informational message.
+        Otherwise, it logs a warning message with the status code and response text.
+        The method returns the telemetry properties as a dictionary.
+
+        Returns:
+            dict: The telemetry properties received from the twin server.
+        """
         res = requests.get(
             f"{self.twin_url}/api/2/things/{self.thing_id}/features/telemetry/properties",
             headers={"Content-type": "application/json"}
@@ -180,7 +234,20 @@ class Twin(Node):
         return payload
 
     def register_telemetry(self, telemetry_to_register):
-        """ # TODO add docs."""
+        """
+        Registers or updates a telemetry entry with the twin server.
+
+        This method takes a telemetry entry in JSON format, retrieves the current telemetry definitions from the twin server,
+        and updates the list of telemetry definitions to include the new entry. It sends a PUT request to the twin server's API
+        with the updated list. The method logs the success or failure of the telemetry registration or update process and returns
+        the HTTP status code of the PUT request.
+
+        Args:
+            telemetry_to_register (str): A JSON string representing the telemetry entry to be registered or updated.
+
+        Returns:
+            int: The HTTP status code from the telemetry registration or update attempt.
+        """
         req_telemetry = json.loads(telemetry_to_register)
 
         registered_telemetries = self.get_registered_telemetries()
@@ -214,8 +281,21 @@ class Twin(Node):
 
         return res.status_code
 
-    def delete_telemtry(self, telemetry_to_delete):
-        """ # TODO add docs."""
+    def delete_telemetry(self, telemetry_to_delete):
+        """
+        Deletes a telemetry entry from the twin server.
+
+        This method takes a telemetry entry in JSON format, retrieves the current telemetry definitions from the twin server,
+        and updates the list of telemetry definitions to remove the specified entry. It sends a PUT request to the twin server's API
+        with the updated list. The method logs the success or failure of the telemetry deletion process and returns the HTTP status code
+        of the PUT request.
+
+        Args:
+            telemetry_to_delete (str): A JSON string representing the telemetry entry to be deleted.
+
+        Returns:
+            int: The HTTP status code from the telemetry deletion attempt.
+        """
         req_telemetry = json.loads(telemetry_to_delete)
 
         registered_telemetries = self.get_registered_telemetries()
@@ -246,7 +326,7 @@ class Twin(Node):
         return res.status_code
 
     def device_register_data(self):
-        """ # TODO add docs."""
+        """ Constructs the data dictionary required for device registration with the twin server. """
         data = {
             "definition": self.definition,
             "attributes": self.attributes,
@@ -266,6 +346,13 @@ class Twin(Node):
         return data
 
     def connection_status(self):
+        """
+        Checks the connection status to the twin server and updates the internet status.
+
+        This method attempts to establish a TCP connection to the twin server using a socket.
+        If the connection is successful and the device is not registered, it calls the `register_device` method.
+        The internet connection status is then updated accordingly. If the connection fails, it logs a warning message.
+        """
         try:     
             self.socket_ = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket_.connect((self.twin_url.split("@")[1], 1883))

--- a/core/twin_services.py
+++ b/core/twin_services.py
@@ -38,6 +38,7 @@ class TwinServices():
         self.node.create_service(CoreTwin, f"{self.nname}/get_registered_telemetries", self.callback_get_registered_telemetries)
         self.node.create_service(CoreTwin, f"{self.nname}/register_telemetry", self.callback_register_telemetry)
         self.node.create_service(CoreTwin, f"{self.nname}/delete_telemetry", self.callback_delete_telemetry)
+        self.node.create_service(CoreTwin, f"{self.nname}/get_internet_status", self.callback_get_internet_status)
 
 
 
@@ -106,6 +107,12 @@ class TwinServices():
         status_code = self.node.delete_telemtry(payload)
 
         response.output = str(status_code)
+
+        return response
+    
+    def callback_get_internet_status(self, request, response):
+        """" # TODO add docs."""       
+        response.output = str(self.node.internet_status)
 
         return response
         

--- a/core/twin_services.py
+++ b/core/twin_services.py
@@ -40,10 +40,22 @@ class TwinServices():
         self.node.create_service(CoreTwin, f"{self.nname}/delete_telemetry", self.callback_delete_telemetry)
         self.node.create_service(CoreTwin, f"{self.nname}/get_internet_status", self.callback_get_internet_status)
 
-
-
     def callback_get_current_properties(self, request, response):
-        """ # TODO add docs."""
+        """
+        Callback function to handle requests for the current properties of the device's stack.
+
+        This method is used as a ROS service callback to provide the current properties of the device's stack.
+        It retrieves the properties by calling the `get_current_properties` method on the node, converts the properties
+        to a JSON string, and sets this JSON string as the response output.
+
+        Args:
+            request: The service request object. It is not used in this method.
+            response: The service response object. The `output` attribute of this object will be set to the JSON string 
+                    representing the current stack properties.
+
+        Returns:
+            response: The modified service response object with the `output` attribute set to the JSON string of the current stack properties.
+        """
         stack = self.node.get_current_properties()
         
         response.output = json.dumps(stack)
@@ -51,7 +63,20 @@ class TwinServices():
         return response
     
     def callback_get_stack_definition(self, request, response):
-        """ # TODO add docs."""
+        """
+        Service callback to get the stack definition for a given stack ID.
+
+        This method is a ROS 2 service callback that handles requests to retrieve the stack definition.
+        It extracts the stack ID from the request, retrieves the stack definition using the node's `get_stack_definition` method,
+        and sets the definition in the response.
+
+        Args:
+            request: The request object containing the input stack ID.
+            response: The response object to be populated with the stack definition.
+
+        Returns:
+            response: The response object with the output set to the JSON-encoded stack definition.
+        """
         stack_id = request.input
         definition = self.node.get_stack_definition(stack_id)
         
@@ -60,7 +85,20 @@ class TwinServices():
         return response
     
     def callback_set_current_stack(self, request, response):
-        """ # TODO add docs."""
+        """
+        Handles the service request to set the current stack of the device.
+
+        This callback method processes a service request to update the current stack configuration of the device.
+        It extracts the payload from the request, calls the `set_current_stack` method of the node to perform the update, 
+        and sets the status code of the operation in the response.
+
+        Args:
+            request: The service request containing the input payload.
+            response: The service response that will contain the status code of the operation.
+
+        Returns:
+            response: The response with the status code as a string in the output attribute.
+        """
         payload = request.input
         status_code = self.node.set_current_stack(payload)
 
@@ -69,7 +107,20 @@ class TwinServices():
         return response
     
     def callback_get_context(self, request, response):
-        """ # TODO add docs."""
+        """
+        Callback method to handle requests for the device context.
+
+        This method is invoked when a service request for the device context is received. It retrieves the context
+        information of the device using the `get_context` method of the node, serializes it into a JSON string,
+        and assigns it to the response's output field.
+
+        Args:
+            request: The service request object (not used in this method).
+            response: The service response object that will contain the context information.
+
+        Returns:
+            response: The service response object with the context information in the output field.
+        """
         context = self.node.get_context()
         
         response.output = json.dumps(context)
@@ -77,7 +128,20 @@ class TwinServices():
         return response
 
     def callback_register_device(self, request, response):
-        """ # TODO add docs."""
+        """
+        Registers the device with the twin server.
+
+        This method is invoked as a callback to handle a request for registering the device with the twin server.
+        It calls the 'register_device' method of the associated 'node' instance to perform the registration process.
+        The status code returned by the 'register_device' method is converted to a string and set as the output in the response object.
+
+        Args:
+            request: The request object containing input data.
+            response: The response object for returning output data.
+
+        Returns:
+            response: The response object containing the status code of the device registration attempt.
+        """
         status_code = self.node.register_device()
 
         response.output = str(status_code)
@@ -85,7 +149,20 @@ class TwinServices():
         return response
     
     def callback_get_registered_telemetries(self, request, response):
-        """ # TODO add docs."""
+        """
+        Retrieves registered telemetry properties from the twin server.
+
+        This method is a callback function designed to handle a request for retrieving registered telemetry properties from the twin server.
+        It invokes the 'get_telemetry' method of the associated 'node' instance to fetch the telemetry data.
+        The telemetry data is then assigned to the 'output' attribute of the response object, which is returned.
+
+        Args:
+            request: The request object containing input data.
+            response: The response object for returning output data.
+
+        Returns:
+            response: The response object containing the registered telemetry properties.
+        """
         telemetry_data = self.node.get_telemetry()
 
         response.output = telemetry_data
@@ -93,7 +170,21 @@ class TwinServices():
         return response
     
     def callback_register_telemetry(self, request, response):
-        """ # TODO add docs."""
+        """
+        Registers telemetry with the twin server.
+
+        This method is a callback function designed to handle a request for registering telemetry with the twin server.
+        It retrieves the payload from the input attribute of the request object.
+        The payload is then passed to the 'register_telemetry' method of the associated 'node' instance to perform the registration.
+        The status code returned by the 'register_telemetry' method is converted to a string and set as the output in the response object.
+
+        Args:
+            request: The request object containing input data.
+            response: The response object for returning output data.
+
+        Returns:
+            response: The response object containing the status code of the telemetry registration attempt.
+        """
         payload = request.input
         status_code = self.node.register_telemetry(payload)
 
@@ -102,16 +193,43 @@ class TwinServices():
         return response
 
     def callback_delete_telemetry(self, request, response):
-        """ # TODO add docs."""
+        """
+        Deletes telemetry from the twin server.
+
+        This method is a callback function designed to handle a request for deleting telemetry from the twin server.
+        It retrieves the payload from the input attribute of the request object.
+        The payload is then passed to the 'delete_telemetry' method of the associated 'node' instance to perform the deletion.
+        The status code returned by the 'delete_telemetry' method is converted to a string and set as the output in the response object.
+
+        Args:
+            request: The request object containing input data.
+            response: The response object for returning output data.
+
+        Returns:
+            response: The response object containing the status code of the telemetry deletion attempt.
+        """
         payload = request.input
-        status_code = self.node.delete_telemtry(payload)
+        status_code = self.node.delete_telemetry(payload)
 
         response.output = str(status_code)
 
         return response
     
     def callback_get_internet_status(self, request, response):
-        """" # TODO add docs."""       
+        """
+        Retrieves the internet connection status.
+
+        This method is a callback function designed to handle a request for retrieving the internet connection status.
+        It retrieves the internet status from the associated 'node' instance and converts it to a string.
+        The string representation of the internet status is set as the output in the response object, which is returned.
+
+        Args:
+            request: The request object containing input data.
+            response: The response object for returning output data.
+
+        Returns:
+            response: The response object containing the internet connection status.
+        """
         response.output = str(self.node.internet_status)
 
         return response

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
         (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
-        (os.path.join("share", package_name, "launch"), glob("launch/*.yaml")),
+        (os.path.join("share", package_name, "launch"), glob("launch/*.py")),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
Fix for issue #5.

Added timer to check if there is an active internet connection. If connection is disrupted for some reason MUTO doesn't crash. If MUTO starts without an active internet connection, it waits before registering device, subscribing to mqtt etc.