### PR TITLE
Added a new model

### DIFF
--- a/core/model/muto_archive.py
+++ b/core/model/muto_archive.py
@@ -1,0 +1,60 @@
+import os
+import requests
+import tarfile
+
+
+class MutoArchive:
+    def __init__(self) -> None:
+        self.usr = os.path.expanduser("~")
+        self.container = None
+
+    def download_workspace(self, url):
+        container_dir = f"{self.usr}/muto_workspaces"
+        if not os.path.exists(container_dir):
+            os.makedirs(container_dir)
+
+        local_filename = url.split("/")[-1]
+        print(f"local filename is: {local_filename}")
+        local_filepath = os.path.join(container_dir, local_filename)
+        print(f"local filepath is: {local_filepath}")
+
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            total_length = r.headers.get("content-length")
+            print(f"total length is: {total_length}")
+
+            with open(local_filepath, "wb") as f:
+                if total_length is None:
+                    f.write(r.content)
+                else:
+                    downloaded = 0
+                    total_length = int(total_length)
+                    for chunk in r.iter_content(chunk_size=8192):
+                        if chunk:
+                            f.write(chunk)
+                            downloaded += len(chunk)
+                            done = int(50 * downloaded / total_length)
+                            print(
+                                f"\r[{'=' * done}{' ' * (50-done)}] {downloaded / total_length:.2%}",
+                                end="",
+                            )
+
+        print("\nWorkspace download complete.")
+        return local_filepath
+
+    def decompress_into_local(self, tar_path):
+        try:
+            if not tarfile.is_tarfile(tar_path):
+                raise ValueError(f"{tar_path} is not a valid tar file.")
+
+            muto_ws = f"{self.usr}/muto_workspaces"
+            if not os.path.exists(muto_ws):
+                os.mkdir(muto_ws)
+
+            with tarfile.open(tar_path, "r") as tar:
+                tar.extractall(path=muto_ws)
+                print(f"Decompressed {tar_path} into {muto_ws}")
+        except Exception as e:
+            raise Exception(
+                f"Exception while decompressing the workspace to the local machine: {e}"
+            )

--- a/core/twin.py
+++ b/core/twin.py
@@ -93,7 +93,7 @@ class Twin(Node):
         self.name = self.get_parameter("name").value
         self.type = self.get_parameter("type").value
         self.unique_name = (
-            f"{self.namespace}:{str(uuid.uuid4())}" if self.anonymous else self.name
+            f"{self.type}.{str(uuid.uuid4())}" if self.anonymous else self.name
         )
         self.attributes = json.loads(self.get_parameter("attributes").value)
         self.definition = self.get_parameter("definition").value
@@ -199,17 +199,16 @@ class Twin(Node):
             int: The HTTP status code from the final registration attempt.
         """
         res = requests.patch(
-            f"{self.twin_url}/api/2/things/{self.unique_name}",
+            f"{self.twin_url}/api/2/things/{self.thing_id}",
             headers={"Content-type": "application/merge-patch+json"},
             json=self.device_register_data(),
         )
-        self.get_logger().info(f"unique name: {self.unique_name}")
 
         if res.status_code == 400:
             data = self.device_register_data()
             data["policyId"] = self.thing_id
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.unique_name}",
+                f"{self.twin_url}/api/2/things/{self.thing_id}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )
@@ -217,13 +216,13 @@ class Twin(Node):
         if res.status_code == 404:
             data = self.device_register_data()
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.unique_name}",
+                f"{self.twin_url}/api/2/things/{self.thing_id}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )
 
-        if res.status_code in (201, 204):
-            self.get_logger().info("Device registered successfully.")
+        if res.status_code == 201 or res.status_code == 204:
+            self.get_logger().info(f"Device registered successfully.")
             self.is_device_registered = True
         else:
             self.get_logger().warn(

--- a/core/twin.py
+++ b/core/twin.py
@@ -199,7 +199,7 @@ class Twin(Node):
             int: The HTTP status code from the final registration attempt.
         """
         res = requests.patch(
-            f"{self.twin_url}/api/2/things/{self.unique_name}",
+            f"{self.twin_url}/api/2/things/{self.thing_id}",
             headers={"Content-type": "application/merge-patch+json"},
             json=self.device_register_data(),
         )
@@ -208,7 +208,7 @@ class Twin(Node):
             data = self.device_register_data()
             data["policyId"] = self.thing_id
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.unique_name}",
+                f"{self.twin_url}/api/2/things/{self.thing_id}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )
@@ -216,7 +216,7 @@ class Twin(Node):
         if res.status_code == 404:
             data = self.device_register_data()
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.unique_name}",
+                f"{self.twin_url}/api/2/things/{self.thing_id}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )

--- a/core/twin.py
+++ b/core/twin.py
@@ -199,7 +199,7 @@ class Twin(Node):
             int: The HTTP status code from the final registration attempt.
         """
         res = requests.patch(
-            f"{self.twin_url}/api/2/things/{self.thing_id}",
+            f"{self.twin_url}/api/2/things/{self.unique_name}",
             headers={"Content-type": "application/merge-patch+json"},
             json=self.device_register_data(),
         )
@@ -208,7 +208,7 @@ class Twin(Node):
             data = self.device_register_data()
             data["policyId"] = self.thing_id
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.thing_id}",
+                f"{self.twin_url}/api/2/things/{self.unique_name}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )
@@ -216,7 +216,7 @@ class Twin(Node):
         if res.status_code == 404:
             data = self.device_register_data()
             res = requests.put(
-                f"{self.twin_url}/api/2/things/{self.thing_id}",
+                f"{self.twin_url}/api/2/things/{self.unique_name}",
                 headers={"Content-type": "application/json"},
                 json=data,
             )

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,30 @@
-from setuptools import setup
 import os
 from glob import glob
+from setuptools import setup
 
 package_name = 'core'
 
 setup(
     name=package_name,
-    version='1.0.0',
-    packages=[package_name],
+    version='0.0.0',
+    packages=[
+        package_name,
+        f"{package_name}.model"
+    ],
     data_files=[
-        ('share/ament_index/resource_index/packages',['resource/' + package_name]),
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        (os.path.join("share", package_name, "launch"), glob("launch/*.launch.py")),
         (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
-        (os.path.join("share", package_name, "launch"), glob("launch/*.py")),
+        (os.path.join("share", package_name, "log"), glob("log/*.log")),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
     maintainer='Alp SARICA',
     maintainer_email='alp.sarica@eteration.com',
-    description='Eclipse Muto Core Package',
-    license='Eclipse Public License v2.0',
+    description="Eclipse Muto Core Package",
+    license='EPL',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ package_name = 'core'
 
 setup(
     name=package_name,
-    version='0.0.0',
+    version='1.0.0',
     packages=[
         package_name,
         f"{package_name}.model"
@@ -17,14 +17,13 @@ setup(
         ('share/' + package_name, ['package.xml']),
         (os.path.join("share", package_name, "launch"), glob("launch/*.launch.py")),
         (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
-        (os.path.join("share", package_name, "log"), glob("log/*.log")),
     ],
     install_requires=['setuptools'],
     zip_safe=True,
     maintainer='Alp SARICA',
     maintainer_email='alp.sarica@eteration.com',
     description="Eclipse Muto Core Package",
-    license='EPL',
+    license='Eclipse Public License v2.0',
     tests_require=['pytest'],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
- A MutoArchive model added for the use of composer where it will serve the purpose of downloading a workspace from a repo
- Added an extra step to `register_device` method for configuring the default device features before registering. This could be adjusted from the parameter file like below:
```yaml
features:
    feature1: value1
```

Above will be published to the twin while initially registering the device like following:

```json
{
    "features": { "feature1" : "value1" }
} 
```